### PR TITLE
[EXP-9873] Use compile_env instead of get_env

### DIFF
--- a/lib/segment.ex
+++ b/lib/segment.ex
@@ -5,7 +5,7 @@ defmodule Segment do
 
   alias Segment.{Context, Server}
 
-  @module Application.get_env(:segment, :api) || Server
+  @module Application.compile_env(:segment, :api) || Server
 
   defdelegate send_track(t), to: @module
   defdelegate send_track(user_id, event, properties \\ %{}, context \\ Context.new()), to: @module
@@ -14,7 +14,9 @@ defmodule Segment do
   defdelegate send_identify(user_id, traits \\ %{}, context \\ Context.new()), to: @module
 
   defdelegate send_screen(s), to: @module
-  defdelegate send_screen(user_id, name \\ "", properties \\ %{}, context \\ Context.new()), to: @module
+
+  defdelegate send_screen(user_id, name \\ "", properties \\ %{}, context \\ Context.new()),
+    to: @module
 
   defdelegate send_alias(a), to: @module
   defdelegate send_alias(user_id, previous_id, context \\ Context.new()), to: @module
@@ -23,5 +25,7 @@ defmodule Segment do
   defdelegate send_group(user_id, group_id, traits \\ %{}, context \\ Context.new()), to: @module
 
   defdelegate send_page(p), to: @module
-  defdelegate send_page(user_id, name \\ "", properties \\ %{}, context \\ Context.new()), to: @module
+
+  defdelegate send_page(user_id, name \\ "", properties \\ %{}, context \\ Context.new()),
+    to: @module
 end

--- a/lib/segment/analytics.ex
+++ b/lib/segment/analytics.ex
@@ -3,7 +3,7 @@ defmodule Segment.Analytics do
 
   require Logger
 
-  @adapter Application.get_env(:segment, :http_adapter) || Segment.HTTP.HTTPoison
+  @adapter Application.compile_env(:segment, :http_adapter) || Segment.HTTP.HTTPoison
 
   def track(t = %Track{}) do
     call(t)

--- a/lib/segment/application.ex
+++ b/lib/segment/application.ex
@@ -1,7 +1,7 @@
 defmodule Segment.Application do
   use Application
 
-  @api Application.get_env(:segment, :api) || Segment.Server
+  @api Application.compile_env(:segment, :api) || Segment.Server
 
   def start(_type, _args) do
     import Supervisor.Spec, warn: false

--- a/lib/segment/server.ex
+++ b/lib/segment/server.ex
@@ -11,10 +11,10 @@ defmodule Segment.Server do
 
   require Logger
 
-  @adapter Application.get_env(:segment, :http_adapter) || Segment.HTTP.HTTPoison
+  @adapter Application.compile_env(:segment, :http_adapter) || Segment.HTTP.HTTPoison
 
   def start_link(args) do
-    GenServer.start_link(__MODULE__, args, [name: __MODULE__])
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
   end
 
   def send_track(t = %Track{}) do
@@ -54,7 +54,7 @@ defmodule Segment.Server do
   end
 
   def send_group(g = %Group{}) do
-   send(g)
+    send(g)
   end
 
   def send_group(user_id, group_id, traits \\ %{}, context \\ Context.new()) do
@@ -76,14 +76,15 @@ defmodule Segment.Server do
   end
 
   def handle_cast(event, state) do
-    resp = @adapter.post!(
-      event.method,
-      Poison.encode!(event),
-      [],
-      [ssl: [{:versions, [:'tlsv1.2']}]]
-    )
+    resp =
+      @adapter.post!(
+        event.method,
+        Poison.encode!(event),
+        [],
+        ssl: [{:versions, [:"tlsv1.2"]}]
+      )
 
-    Logger.debug fn -> "#{inspect resp}" end
+    Logger.debug(fn -> "#{inspect(resp)}" end)
     {:noreply, state}
   end
 end


### PR DESCRIPTION
Uses Application.comple_env instead of Application.get_env. The use of Application.get_env won't actually be doing anything because its being used module attributes which are set at compile time and Application.get_env is meant for runtime.

#### How to test

- Pull down this repo and check out this branch
- Then from expert360_com link the dependency to the local repo. Open `backend/apps/notifier/mix.exs` and set the segment dependency to `{:segment, path: "../../../../analytics-elixir}`. 
- When you run `mix phx.server` from expert360_com search in the terminal for `segment` and you should see it starting `Segement.Sandbox` instead of `Segment.Server`.
